### PR TITLE
For now, use a blockinfile to add the additional apiserver arguments

### DIFF
--- a/tasks/configure-apiserver.yml
+++ b/tasks/configure-apiserver.yml
@@ -1,0 +1,11 @@
+---
+- name: Add custom args to the end of the kube-apiserver args
+  blockinfile:
+    path: "{{ kubernetes_apiserver_config }}"
+    block: "{{ kubernetes_apiserver_extra_args | to_nice_yaml | trim | indent(4, first=True) }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK for dudefellah.kubernetes - kube-apiserver args"
+    insertafter: "    - --"
+  vars:
+    ansible_python_interpreter: "{{ kubernetes_python_interpreter }}"
+  when:
+    - "kubernetes_master|bool"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,8 @@
       "kubernetes_force" option if you really want continue anyway.
   when:
     - "not kubernetes_force"
+    - "_kubernetes_control_plane_replicas is defined"
+    - "_kubernetes_control_plane_replicas is not none"
     - "(_kubernetes_control_plane_replicas|length) % 2 != 0"
 
 - name: Do master node install process
@@ -121,6 +123,12 @@
   include_tasks: "{{ role_path }}/tasks/networking/main.yml"
   tags:
     - kubernetes_network
+
+- name: Configure the Kubernetes API server
+  include_tasks: configure-apiserver.yml
+  tags:
+    - kubernetes_master
+    - kubernetes_apiserver
 
 - name: Manage taints on the control plane and master
   include_tasks: manage-taints.yml


### PR DESCRIPTION
Use blockinfile to add extra values to the kube-apiserver command args. It seems to work, but is kind of an imperfect way to accomplish the task.